### PR TITLE
refactor: replace deprecated Buffer() constructor with Buffer.from/Bu…

### DIFF
--- a/lib/aes.js
+++ b/lib/aes.js
@@ -118,7 +118,7 @@ function aes_cbc_encrypt(key, msg, iv) {
     }
 
     if(iv === undefined){
-        iv = new Buffer(16);
+        iv = Buffer.alloc(16);
         iv.fill(0);
     } else {
         iv = ut.toBuffer(iv);

--- a/lib/bitwise.js
+++ b/lib/bitwise.js
@@ -20,7 +20,7 @@ function xor(arr1, arr2) {
         ret[i] = arr1[i] ^ arr2[i];
     }
 
-    var result = new Buffer(ret);
+    var result = Buffer.from(ret);
     return result.toString('hex').toUpperCase();
 }
 

--- a/lib/des.js
+++ b/lib/des.js
@@ -129,7 +129,7 @@ function des_cbc_encrypt(key, msg, iv) {
     }
 
     if (iv === undefined) {
-        iv = new Buffer(8);
+        iv = Buffer.alloc(8); 
         iv.fill(0);
     } else {
         iv = ut.toBuffer(iv);
@@ -183,7 +183,7 @@ function des_cbc_decrypt(key, msg, iv) {
     }
 
     if (iv === undefined) {
-        iv = new Buffer(8);
+        iv = Buffer.alloc(8);
         iv.fill(0);
     } else {
         iv = ut.toBuffer(iv);

--- a/lib/padding.js
+++ b/lib/padding.js
@@ -22,7 +22,7 @@ function ISO9797Method1(buff, block_size) {
     if(pad_len == block_size) {
         return ut.toHexString(buff);
     }
-    var pad = new Buffer(pad_len);
+    var pad = Buffer.alloc(pad_len);
     pad.fill(0);
 
     return ut.toHexString(Buffer.concat([buff, pad]));
@@ -43,7 +43,7 @@ function ISO9797Method2(buff, block_size) {
     buff = ut.toBuffer(buff);
     var pad_len = block_size - (buff.length % block_size);
 
-    var pad = new Buffer(pad_len);
+    var pad = Buffer.alloc(pad_len);
     pad.fill(0);
     pad[0] = 0x80;
 
@@ -104,7 +104,7 @@ function pkcs7_padding(buff, block_size) {
 
     var pad_len = block_size - (buff.length % block_size);
 
-    var pad = new Buffer(pad_len);
+    var pad = Buffer.alloc(pad_len);
     pad.fill(pad.length);
     return ut.toHexString(Buffer.concat([buff, pad]));
 }

--- a/lib/seed.js
+++ b/lib/seed.js
@@ -88,7 +88,7 @@ function seed_cbc_encrypt(key, msg, iv) {
     }
     
     if(iv === undefined){
-        iv = new Buffer(16);
+        iv = Buffer.alloc(16);
         iv.fill(0);
     } else {
         iv = ut.toBuffer(iv);
@@ -128,7 +128,7 @@ function seed_cbc_decrypt(key, msg, iv) {
     }
 
     if(iv === undefined){
-        iv = new Buffer(16);
+        iv = Buffer.alloc(16);
         iv.fill(0);
     } else {
         iv = ut.toBuffer(iv);

--- a/lib/util.js
+++ b/lib/util.js
@@ -43,15 +43,15 @@ function toBuffer(data) {
         return data;
     } else if (typeof data === 'string') {
         data = strip(data);
-        return new Buffer(data, 'hex');
+        return Buffer.from(data, 'hex');
     } else if (typeof data == 'number') {
         var h = data.toString(16).toUpperCase();
         if ((h.length & 1) == 1) {
             h = '0' + h;
         }
-        return new Buffer(h, 'hex');
+        return Buffer.from(h, 'hex');
     } else {
-        return new Buffer(0);
+        return Buffer.alloc(0);
     }
 }
 

--- a/test/des.js
+++ b/test/des.js
@@ -42,7 +42,7 @@ exports.des = {
         },
         'single block' : function() {
             var key = '4041424344454647';
-            var plain = new Buffer('ABCDEFGH', 'ascii');
+            var plain = Buffer.from('ABCDEFGH', 'ascii');
             plain = plain.toString('hex');
             var cipher = '9DF73E6786F342CD';
 
@@ -51,7 +51,7 @@ exports.des = {
         },
         'multiple block' : function() {
             var key = '4041424344454647';
-            var plain = new Buffer('ABCDEFGHabcdefgh', 'ascii');
+            var plain = Buffer.from('ABCDEFGHabcdefgh', 'ascii');
             plain = plain.toString('hex');
 
             var cipher = '9DF73E6786F342CDAC43F7565CCE42ED';
@@ -78,7 +78,7 @@ exports.des = {
             var key = '505152535455565758595A5B5C5D5E5F';
             var key1 = '5051525354555657';
             var key2 = '58595A5B5C5D5E5F';
-            var plain = new Buffer('20141027', 'ascii');
+            var plain = Buffer.from('20141027', 'ascii');
             plain = plain.toString('hex');
 
             cipher = plain;
@@ -163,7 +163,7 @@ exports.des = {
         },
         'single block 2': function () {
             var key = '4041424344454647';
-            var text = new Buffer('ABCDEFGH', 'ascii');
+            var text = Buffer.from('ABCDEFGH', 'ascii');
             text = text.toString('hex');
             var iv = '0000000000000000';
 

--- a/test/hash.js
+++ b/test/hash.js
@@ -33,7 +33,7 @@ exports.hash = {
             result = hash.digest('sha1', message);
             assert(answer === result);
 
-            message = new Buffer('Hello World', 'ascii');
+            message = Buffer.from('Hello World', 'ascii');
             answer = '0A4D55A8D778E5022FAB701977C5D840BBC486D0';
             result = hash.digest('sha1', message);
             assert(answer === result);

--- a/test/mac.js
+++ b/test/mac.js
@@ -29,8 +29,8 @@ exports.mac = {
         assert(answer === result);
     },
     'hmac' : function() {
-        var msg = new Buffer('The quick brown fox jumps over the lazy dog', 'ascii');
-        var key = new Buffer('key', 'ascii');
+        var msg = Buffer.from('The quick brown fox jumps over the lazy dog', 'ascii');
+        var key = Buffer.from('key', 'ascii');
         var result;
 
         result = mac.hmac_sha1(key, msg);

--- a/test/padding.js
+++ b/test/padding.js
@@ -8,7 +8,7 @@ var assert = require('assert');
 
 exports.padding = {
     'ISO9797Method1' : function() {
-        var buffer = new Buffer('Now is the time for all ', 'ascii');
+        var buffer = Buffer.from('Now is the time for all ', 'ascii');
         var result = padding.ISO9797Method1(buffer, 8);
         assert.equal(result.toString('hex').toUpperCase(), '4E6F77206973207468652074696D6520666F7220616C6C20');
     },

--- a/test/rsa.js
+++ b/test/rsa.js
@@ -17,7 +17,7 @@ exports.rsa = {
 
         assert(answer === result);
 
-        result = new Buffer(result, 'hex');
+        result = Buffer.from(result, 'hex');
 
         //step 1. public key modulus and certificate have same length
         assert(m.length == text.length);


### PR DESCRIPTION
…ffer.alloc

Replaced all usages of the deprecated  constructor across the codebase with
 or  to address Node.js [DEP0005] warnings and improve security.

- Updated library files in  to use safe Buffer methods
- Updated test files accordingly
- Ensured all tests pass without deprecation warnings

This change removes security/usability concerns from deprecated Buffer usage.